### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-calendar/security/code-scanning/1](https://github.com/RumenDamyanov/php-calendar/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to read-only access. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). Since there is only one job (`build`), either location is acceptable, but setting it at the workflow level is more concise and future-proof. The change involves adding the following lines near the top of the file, after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
